### PR TITLE
Adding nvme_mapping_run variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+# Run ebs-nvme-mapping.sh by ansible
+nvme_mapping_run: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,7 @@
     - name: Ensure script runs once
       command: /usr/local/bin/ebs-nvme-mapping
       changed_when: False
+      when: nvme_mapping_run|bool
 
   when: not(nvme_exist.stdout | regex_search('No NVMe devices detected.'))
 


### PR DESCRIPTION
In few case we might not want to run the script with ansible but only
with udev. 

By default nvme_mapping_run is true, that means it will work as
previously (run the .sh script by ansible)