### PR TITLE
fix bug when nvme returns /dev/sda1 not just sda1

### DIFF
--- a/files/ebs-nvme-mapping.sh
+++ b/files/ebs-nvme-mapping.sh
@@ -3,7 +3,7 @@
 PATH="${PATH}:/usr/sbin"
 
 for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
-  mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+  mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g' | sed 's/dev//g' | sed 's/\///g')
   if [[ "/dev/${mapping}" == /dev/* ]]; then
     ( test -b "${blkdev}" && test -L "/dev/${mapping}" ) || ln -s "${blkdev}" "/dev/${mapping}"
   fi


### PR DESCRIPTION
So after an EC2 restart, now the script that works started to fail.

The problem is that `nvme id-ctrl --raw-binary "/dev/nvme1n1"` returns `/dev/sda1` instead of just `sda1` as before. So we need to remove `/dev/` too, so that the script can continue.