### PR TITLE
script and udev rule for deterministic ephemeral devices

### DIFF
--- a/files/999-aws-ebs-nvme.rules
+++ b/files/999-aws-ebs-nvme.rules
@@ -1,1 +1,2 @@
-ACTION=="add", SUBSYSTEM=="block", KERNEL=="nvme[1-26]n1", ATTRS{model}=="Amazon Elastic Block Store              ", RUN+="/usr/local/bin/ebs-nvme-mapping"
+SUBSYSTEM=="block", KERNEL=="nvme[0-9]*n[0-9]*", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM+="/usr/local/bin/ebs-nvme-mapping /dev/%k" SYMLINK+="%c"
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon EC2 NVMe Instance Storage", PROGRAM="/usr/local/bin/nextephemeraldevice %k", SYMLINK+="%c"

--- a/files/ebs-nvme-mapping.sh
+++ b/files/ebs-nvme-mapping.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
+# To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
 
-PATH="${PATH}:/usr/sbin"
+if [[ -z nvme ]]; then
+  echo "ERROR: NVME tools not installed." >> /dev/stderr
+  exit 1
+fi
 
-for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
-  mapping=$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g' | sed 's/dev//g' | sed 's/\///g')
-  if [[ "/dev/${mapping}" == /dev/* ]]; then
-    ( test -b "${blkdev}" && test -L "/dev/${mapping}" ) || ln -s "${blkdev}" "/dev/${mapping}"
-  fi
-done
+if [[ ! -b ${1} ]]; then
+  echo "ERROR: cannot find block device ${1}" >> /dev/stderr
+  exit 1
+fi
+
+# capture 32 bytes at an offset of 3072 bytes from the raw-binary data
+# not all block devices are extracted with /dev/ prefix
+# use `xvd` prefix instead of `sd`
+# remove all trailing space
+nvme_link=$( \
+  nvme id-ctrl --raw-binary "${1}" | \
+  cut -c3073-3104 | \
+  sed 's/^\/dev\///g'| \
+  tr -d '[:space:]' \
+);
+echo $nvme_link;

--- a/files/nextephemeraldevice.sh
+++ b/files/nextephemeraldevice.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# To be used with the udev rule: /etc/udev/rules.d/999-aws-ebs-nvme.rules
+
+kern_name=${1}
+incr=0
+while [[ -e "/dev/ephemeral${incr}" ]] && [[ $(readlink "/dev/ephemeral${incr}") != "${kern_name}" ]]; do
+  incr=$[$i+1]
+done
+echo "ephemeral${incr}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,13 +13,16 @@
 
 - name: Install files
   block:
-    - name: Install ebs mapper script
+    - name: Install ebs and ephemeral mapper scripts
       copy:
-        src: "{{ role_path }}/files/ebs-nvme-mapping.sh"
-        dest: "/usr/local/bin/ebs-nvme-mapping"
+        src: "{{ role_path }}/files/{{ item }}.sh"
+        dest: "/usr/local/bin/{{ item }}"
         owner: root
         group: root
         mode: 0755
+      loop:
+        - ebs-nvme-mapping
+        - nextephemeraldevice
 
     - name: Install udev rules
       copy:


### PR DESCRIPTION
Catching up with https://github.com/oogali/ebs-automatic-nvme-mapping and adding a script for deterministic ephemeral device names

Ephemeral udev rule and script were tested on `systemd-udev`

https://www.freedesktop.org/software/systemd/man/udev.html

PR: https://github.com/oogali/ebs-automatic-nvme-mapping/pull/9

Worked on this with @thecubed